### PR TITLE
Replace char '/' from song name

### DIFF
--- a/ytmdl/yt.py
+++ b/ytmdl/yt.py
@@ -59,6 +59,7 @@ def dw(value, song_name='ytmdl_temp.mp3'):
 
         # Replace the spaces with hashes
         song_name = song_name.replace(' ', '#')
+        song_name = song_name.replace('/', '#')
 
         # The directory where we will download to.
         dw_dir = defaults.DEFAULT.SONG_TEMP_DIR


### PR DESCRIPTION
Download fails due to '/' char in song name

Example: Dua by R3zR (https://www.youtube.com/watch?v=ZSHL0ttI7wU)

Try downloading this song with `ytmdl`.

```ytmdl R3zR Dua```

Select 1st option.

It fails with following error:
```ERROR: [Errno 2] No such file or directory: '/home/nilesh/Music/ytmdl/R3zR#-#Dua#/#दुआ###🎧#Bass#Boosted#🎧.mp3'```