### PR TITLE
Use XDG directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ req_pkgs = [
             'colorama',
             'bs4',
             'downloader-cli',
-            'lxml'
+            'lxml',
+            'pyxdg'
         ]
 
 

--- a/ytmdl/defaults.py
+++ b/ytmdl/defaults.py
@@ -1,6 +1,7 @@
 """Contains the definition of class DEFAULT."""
 from ytmdl import setupConfig
 import os
+from xdg.BaseDirectory import xdg_cache_home
 
 
 class DEFAULT:
@@ -13,7 +14,7 @@ class DEFAULT:
     SONG_DIR = setupConfig.GIVE_DEFAULT(1, 'SONG_DIR')
 
     # the temp directory where songs will be modded
-    SONG_TEMP_DIR = os.path.join(HOME_DIR, '.cache', 'ytmdl')
+    SONG_TEMP_DIR = os.path.join(xdg_cache_home, 'ytmdl')
 
     # The path to keep cover image
     COVER_IMG = os.path.join(SONG_TEMP_DIR, 'cover.jpg')

--- a/ytmdl/logger.py
+++ b/ytmdl/logger.py
@@ -4,6 +4,8 @@ import datetime
 import os
 from ytmdl.prepend import PREPEND
 
+from xdg.BaseDirectory import xdg_cache_home
+
 
 class Logger:
     """
@@ -14,7 +16,7 @@ class Logger:
         self.name = name
         self._file_format = ''
         self._console_format = ''
-        self._log_file = Path('~/.cache/ytmdl/logs/log.cat').expanduser()
+        self._log_file = Path(os.path.join(xdg_cache_home, 'ytmdl/logs/log.cat'))
         self._check_logfile()
         self._level_number = {
                                 'DEBUG': 0,
@@ -31,6 +33,7 @@ class Logger:
         If not present then create it.
         """
         if not self._log_file.exists():
+            print(self._log_file)
             if not self._log_file.parent.exists():
                 os.makedirs(self._log_file.parent)
             f = open(self._log_file, 'w')

--- a/ytmdl/setupConfig.py
+++ b/ytmdl/setupConfig.py
@@ -3,6 +3,8 @@
 import os
 import re
 from ytmdl.logger import Logger
+from xdg.BaseDirectory import xdg_config_home
+
 
 config_text = '#*****************************************#\n\
 #*-------------config for ytmdl ----------#\n\
@@ -71,7 +73,7 @@ class DEFAULTS:
         self.SONG_QUALITY = '320'
 
         # The config path
-        self.CONFIG_PATH = os.path.join(self.HOME_DIR, '.config', 'ytmdl')
+        self.CONFIG_PATH = os.path.join(xdg_config_home, 'ytmdl')
 
     def _get_music_dir(self):
         """Get the dir the file will be saved to."""


### PR DESCRIPTION
Use Freedesktop's [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), along with their [implementation of the specification](https://freedesktop.org/wiki/Software/pyxdg/).

This is useful for people who have set their home directory read only and have set custom environment variables (`XDG_CONFIG_HOME` and `XDG_CACHE_HOME`). Since the respective defaults are `$HOME/.config` and `$HOME/.cache`, this will not disrupt the workflow of existing users.