### PR TITLE
Fix quiet mode

### DIFF
--- a/bin/ytmdl
+++ b/bin/ytmdl
@@ -311,7 +311,7 @@ def main(args):
         prepend.PREPEND(1)
         print('Setting data...')
 
-        option = song.setData(TRACK_INFO, is_quiet, conv_name, passed_choice)
+        option = song.setData(TRACK_INFO, is_quiet, conv_name, choice)
 
         if type(option) is not int:
             logger.critical('ERROR: {}'.format(option))

--- a/ytmdl/song.py
+++ b/ytmdl/song.py
@@ -126,13 +126,12 @@ def setData(SONG_INFO, is_quiet, song_path, choice=None):
 
     try:
         # If more than one choice then call getChoice
+        option = 0
         if len(SONG_INFO) > 1:
             if not is_quiet:
                 option = getChoice(SONG_INFO, 'metadata')
             elif choice is not None and choice in range(1,len(SONG_INFO)):
                 option = choice
-        else:
-            option = 0
 
         SONG_PATH = os.path.join(defaults.DEFAULT.SONG_TEMP_DIR,
                                  song_path)


### PR DESCRIPTION
Hi, i fixed a couple of bugs in the handling of song metedata choice that made "quiet mode" crash
In particular:
- the selected choice was ignored when calling song.setData
- when song.setData was called with choice 0 or None the local variable "option" was not set which resulted in a crash