### PR TITLE
Choose which metadata api providers to use in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,10 +196,11 @@ This will download the default config from the repo to your ```~/.config/ytmdl``
 
 ### Supported options to change are:
 
-| Name           |                                                    |
-|:--------------:|----------------------------------------------------|
-| `SONG_DIR`     | Directory to save the songs in after editing       |
-| `SONG_QUALITY` | Quality of the song                                |
+| Name                 |                                                    |
+|:--------------------:|----------------------------------------------------|
+| `SONG_DIR`           | Directory to save the songs in after editing       |
+| `SONG_QUALITY`       | Quality of the song                                |
+| `METADATA_PROVIDERS` | Which API providers to use for metadata            |
 
 #### SONG_DIR also takes values that are extracted from the song
 ##### Example format is `/your/desired/path$Album->Artist->Title` to save in the following way

--- a/ytmdl/defaults.py
+++ b/ytmdl/defaults.py
@@ -3,17 +3,23 @@ from ytmdl import setupConfig
 import os
 from xdg.BaseDirectory import xdg_cache_home
 
+def _providers_string_to_list(val):
+    """Convert string to list if not already"""
+    # Use a set to remove duplicates
+    if type(val) == str:
+        return list(set(val.replace(' ', '').split(',')))
+    return list(set(val))
 
 class DEFAULT:
-    """DEFAULT class contains value of different paths."""
+    """DEFAULT class contains value of different constants."""
 
     # The home dir
     HOME_DIR = os.path.expanduser('~')
 
-    # the directory where songs will be saved
+    # The directory where songs will be saved
     SONG_DIR = setupConfig.GIVE_DEFAULT(1, 'SONG_DIR')
 
-    # the temp directory where songs will be modded
+    # The temp directory where songs will be modded
     SONG_TEMP_DIR = os.path.join(xdg_cache_home, 'ytmdl')
 
     # The path to keep cover image
@@ -21,6 +27,10 @@ class DEFAULT:
 
     # The song quality
     SONG_QUALITY = setupConfig.GIVE_DEFAULT(1, 'QUALITY')
+
+    # The metadata providers
+    METADATA_PROVIDERS = _providers_string_to_list(
+        setupConfig.GIVE_DEFAULT(1, 'METADATA_PROVIDERS'))
 
 
 class FORMAT:

--- a/ytmdl/metadata.py
+++ b/ytmdl/metadata.py
@@ -5,7 +5,9 @@ from ytmdl.stringutils import (
     remove_multiple_spaces, remove_punct, compute_jaccard, remove_stopwords,
     check_keywords
 )
-from ytmdl import gaana
+from ytmdl import gaana, logger, defaults
+
+logger = logger.Logger('metadata')
 
 
 def get_from_itunes(SONG_NAME):
@@ -33,9 +35,9 @@ def get_from_gaana(SONG_NAME):
 def _search_tokens(song_name, song_list):
     """Search song in the cache based on simple each word matching."""
     song_name = remove_punct(
-                    remove_stopwords(
-                        remove_multiple_spaces(song_name).lower()
-                    ))
+        remove_stopwords(
+            remove_multiple_spaces(song_name).lower()
+        ))
     tokens1 = song_name.split()
     cached_songs = song_list
 
@@ -88,35 +90,53 @@ def filterSongs(data, filters=[]):
     return (new_tuple + rest)
 
 
+def _extend_to_be_sorted_and_rest(provider_data, to_be_sorted, rest, filters):
+    """Create the to be sorted and rest lists"""
+    # Before passing for sorting filter the songs
+    # with the passed args
+    if filters:
+        provider_data = filterSongs(provider_data, filters)
+    if provider_data is not None:
+        to_be_sorted.extend(provider_data[:10])
+        rest.extend(provider_data[10:])
+
+
 def SEARCH_SONG(q="Tera Buzz", filters=[]):
     """Do the task by calling other functions."""
     to_be_sorted = []
     rest = []
 
-    # Get from itunes
-    data_itunes = get_from_itunes(q)
-    data_gaana = get_from_gaana(q)
+    metadata_providers = defaults.DEFAULT.METADATA_PROVIDERS
 
-    # Before passing for sorting filter the songs
-    # with the passed args
-    if len(filters) != 0:
-        data_itunes = filterSongs(data_itunes, filters)
-        data_gaana = filterSongs(data_gaana, filters)
+    GET_METADATA_ACTIONS = {
+        'itunes': get_from_itunes,
+        'gaana': get_from_gaana
+    }
 
-    if data_itunes is not None:
-        to_be_sorted = data_itunes[:10]
-        rest = data_itunes[10:]
+    broken_provider_counter = 0
 
-    if data_gaana is not None:
-        to_be_sorted += data_gaana[:10]
-        rest += data_gaana[10:]
+    for provider in metadata_providers:
+        data_provider = GET_METADATA_ACTIONS.get(
+            provider, lambda _: None)(q)
+        if data_provider:
+            _extend_to_be_sorted_and_rest(
+                data_provider, to_be_sorted, rest, filters)
+        else:
+            logger.error('"{}" isn\'t implemented'.format(provider))
+            broken_provider_counter += 1
+    
+    # to_be_sorted will be empty and it will return None anyway, no need
+    # to do it here as well
+    if broken_provider_counter == len(metadata_providers):
+        logger.error("{}".format('No metadata provider in the configuration is '
+                                 'implemented. Please change it to something available '
+                                 'or use the --skip-meta flag'))
 
-    if len(to_be_sorted) == 0:
-        return False
+    if not to_be_sorted:
+        return None
 
     # Send the data to get sorted
     sorted_data = _search_tokens(q, to_be_sorted)
-    # sorted_data = to_be_sorted
 
     # Add the unsorted data
     sorted_data += rest

--- a/ytmdl/setupConfig.py
+++ b/ytmdl/setupConfig.py
@@ -50,6 +50,14 @@ config_text = '''#*****************************************#
 # Supported values are 320 and 192
 #
 #QUALITY = "320"
+#
+#*****************************************#
+# The METADATA_PROVIDERS value is a comma separated
+# values that specifies wich API providers to use for getting
+# the song metadata. Available values right now are: itunes, gaana.
+# Please check the github page of ytmdl for more information.
+#
+#METADATA_PROVIDERS = "itunes, gaana"
 #'''
 
 
@@ -74,6 +82,12 @@ class DEFAULTS:
 
         # The config path
         self.CONFIG_PATH = os.path.join(xdg_config_home, 'ytmdl')
+
+        # The default metadata providers
+        self.METADATA_PROVIDERS = ['itunes', 'gaana']
+
+        # The available metadata providers
+        self.AVAILABLE_METADATA_PROVIDERS = self.METADATA_PROVIDERS + [] # add new ones here
 
     def _get_music_dir(self):
         """Get the dir the file will be saved to."""
@@ -197,6 +211,18 @@ def checkExistence(keyword, value):
             return True
         else:
             return False
+    elif keyword == 'METADATA_PROVIDERS':
+        # Possible values that METADATA_PROVIDERS can take
+        possM = DEFAULTS().AVAILABLE_METADATA_PROVIDERS
+        if not value:
+            logger.warning(
+                "Metadata provider value is empty. Default values will be used.")
+            return False
+        new_val = value.replace(' ', '').split(',')
+        for provider in new_val:
+            if provider not in possM:
+                return False
+        return True
 
 
 def retDefault(keyword):
@@ -205,6 +231,8 @@ def retDefault(keyword):
         return DEFAULTS().SONG_QUALITY
     elif keyword == 'SONG_DIR':
         return DEFAULTS().SONG_DIR
+    elif keyword == 'METADATA_PROVIDERS':
+        return DEFAULTS().METADATA_PROVIDERS
 
 
 def GIVE_DEFAULT(self, keyword):


### PR DESCRIPTION
added ability to choose which providers to use in the config, made it extendable so just a function needs to be created to add another one and some constants changed, fixed bug where if sorted data was empty it returned False instead of None, a little refactoring for clarity