### PR TITLE
ability to change the default format and little refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ This will download the default config from the repo to your ```~/.config/ytmdl``
 | `SONG_DIR`           | Directory to save the songs in after editing       |
 | `SONG_QUALITY`       | Quality of the song                                |
 | `METADATA_PROVIDERS` | Which API providers to use for metadata            |
+| `DEFAULT_FORMAT`     | Default format of the song                         |
 
 #### SONG_DIR also takes values that are extracted from the song
 ##### Example format is `/your/desired/path$Album->Artist->Title` to save in the following way

--- a/bin/ytmdl
+++ b/bin/ytmdl
@@ -94,7 +94,8 @@ def arguments():
                         action='store_true')
     parser.add_argument('--format',
                         help="The format in which the song should be downloaded.\
-                        Default is [MP3]. Available options are [m4a]", default='mp3',
+                        Default is mp3, but can be set in config. Available options are [m4a]", 
+                        default=defaults.DEFAULT.DEFAULT_FORMAT,
                         type=str)
     parser.add_argument('--trim', '-t', help="Trim out the audio from the song. Use \
                         underlying speech and music segmentation engine to determine \
@@ -234,7 +235,7 @@ def main(args):
     logger.debug("Passed format: {}".format(passed_format))
 
     # Check if passed format is support, if not exit.
-    if passed_format not in defaults.FORMAT.valid_formats:
+    if passed_format not in defaults.DEFAULT.VALID_FORMATS:
         logger.critical("Passed format is not supported yet!")
 
     if args.song is not None:

--- a/ytmdl/defaults.py
+++ b/ytmdl/defaults.py
@@ -28,17 +28,10 @@ class DEFAULT:
     # The song quality
     SONG_QUALITY = setupConfig.GIVE_DEFAULT(1, 'QUALITY')
 
+    DEFAULT_FORMAT = setupConfig.GIVE_DEFAULT(1, 'DEFAULT_FORMAT')
+
     # The metadata providers
     METADATA_PROVIDERS = _providers_string_to_list(
         setupConfig.GIVE_DEFAULT(1, 'METADATA_PROVIDERS'))
 
-
-class FORMAT:
-    """
-    Class to handle stuff related to the passed
-    format.
-    """
-    valid_formats = [
-        'mp3',
-        'm4a'
-    ]
+    VALID_FORMATS = setupConfig.DEFAULTS().VALID_FORMATS

--- a/ytmdl/setupConfig.py
+++ b/ytmdl/setupConfig.py
@@ -58,6 +58,10 @@ config_text = '''#*****************************************#
 # Please check the github page of ytmdl for more information.
 #
 #METADATA_PROVIDERS = "itunes, gaana"
+#*****************************************#
+# The DEFAULT_FORMAT denotes what to use as default between
+# m4a and mp3
+#DEFAULT_FORMAT = "mp3"
 #'''
 
 
@@ -88,6 +92,10 @@ class DEFAULTS:
 
         # The available metadata providers
         self.AVAILABLE_METADATA_PROVIDERS = self.METADATA_PROVIDERS + [] # add new ones here
+
+        self.VALID_FORMATS = ['mp3', 'm4a']
+
+        self.DEFAULT_FORMAT = 'mp3'
 
     def _get_music_dir(self):
         """Get the dir the file will be saved to."""
@@ -189,7 +197,6 @@ def check_config_setup():
     # Else it's probably setup
     return True
 
-
 def checkExistence(keyword, value):
     """Check if the user specified value in config is possible."""
     if keyword == 'SONG_DIR':
@@ -198,19 +205,14 @@ def checkExistence(keyword, value):
         if '$' in value:
             pos = value.find('$')
             value = value[:pos]
-
-        if os.path.isdir(value):
-            return True
-        else:
-            return False
+        return os.path.isdir(value)
     elif keyword == 'QUALITY':
         # Possible values that QUALITY can take
         possQ = ['320', '192']
-
-        if value in possQ:
-            return True
-        else:
-            return False
+        return value in possQ
+    elif keyword == 'DEFAULT_FORMAT':
+        possF = DEFAULTS().VALID_FORMATS
+        return value in possF
     elif keyword == 'METADATA_PROVIDERS':
         # Possible values that METADATA_PROVIDERS can take
         possM = DEFAULTS().AVAILABLE_METADATA_PROVIDERS
@@ -232,6 +234,8 @@ def retDefault(keyword):
     """Return the DEFAULT value of keyword."""
     if keyword == 'QUALITY':
         return DEFAULTS().SONG_QUALITY
+    elif keyword == 'DEFAULT_FORMAT':
+        return DEFAULTS().DEFAULT_FORMAT
     elif keyword == 'SONG_DIR':
         return DEFAULTS().SONG_DIR
     elif keyword == 'METADATA_PROVIDERS':


### PR DESCRIPTION
m4a is better for songs in quality, also there isn't any need for conversion after downloading from youtube. The default should still be mp3 because it is the more popular choice, but I find myself passing `--format m4a` always.