### PR TITLE
Improves instructions for manual install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ You can manually install `ytmdl` by closing this repository and running the `set
     ```console
     git clone https://github.com/deepjyoti30/ytmdl   
     ```
+
 1. Move into the `ytmdl` directory and run the `setup.py` script:
 
     ```console

--- a/README.md
+++ b/README.md
@@ -96,11 +96,25 @@ Available in **src_prepare-overlay** [here](https://gitlab.com/src_prepare/src_p
 
 ### Manual
 
-`ytmdl` can be manually installed by the following command
+You can manually install `ytmdl` by closing this repository and running the `setup.py` script.
 
-```console
-git clone https://github.com/deepjyoti30/ytmdl && cd ytmdl && sudo python setup.py install
-```
+1. Install `python3-setuptools` if it isn't already:
+
+    ```console
+     pip install setuptools
+     ```
+
+1. Clone this repo:
+
+    ```console
+    git clone https://github.com/deepjyoti30/ytmdl   
+    ```
+1. Move into the `ytmdl` directory and run the `setup.py` script:
+
+    ```console
+    cd ytmdl
+    sudo python setup.py install
+    ```
 
 ## Usage
 


### PR DESCRIPTION
Initially, I was going to add a sentence saying users should install `python3-setuptools`, but then I started cleaning up the formatting of the whole _manual install_ section. This kind of closes #111, although that issue is stale/closed already.

Feel free to edit this PR if you think it needs it, and merge when ready.