### PR TITLE
Improved prompting the user for manual metadata entry.

### DIFF
--- a/bin/ytmdl
+++ b/bin/ytmdl
@@ -98,7 +98,7 @@ def arguments():
     metadata_group.add_argument("--on-meta-error", help="What to do if adding the metadata fails \
                         for some reasong like lack of metadata or perhaps a network issue. \
                         Options are {}".format(defaults.DEFAULT.ON_ERROR_OPTIONS),
-                        type=str, default=None)
+                        type=str, default='manual')
 
     parser.add_argument('--proxy', help='Use the specified HTTP/HTTPS/SOCKS proxy. To enable '
                         'SOCKS proxy, specify a proper scheme. For example '
@@ -174,7 +174,7 @@ def arguments():
             want to use a different name and continue accordingly.",
         action="store_true"
     )
-    
+
     logger_group = parser.add_argument_group("Logger")
     logger_group.add_argument(
         "--level",
@@ -285,10 +285,10 @@ def main(args):
             post_processing(
                 song_title,
                 song_metadata,
-                passed_format, 
-                path, 
-                start_time, 
-                end_time, 
+                passed_format,
+                path,
+                start_time,
+                end_time,
                 args
             )
         except Exception as e:
@@ -315,7 +315,7 @@ def post_processing(
     args: object
 ) -> None:
     """Handle all the activities post search of the song.
-    
+
     This function will handle the following:
     Convert, Trim, Metadata, Cleaning up.
     """

--- a/bin/ytmdl
+++ b/bin/ytmdl
@@ -116,7 +116,7 @@ def arguments():
     parser.add_argument('--format',
                         help="The format in which the song should be downloaded.\
                         Default is mp3, but can be set in config. Available options are\
-                         {}".format(defaults.DEFAULT.VALID_FORMATS), 
+                         {}".format(defaults.DEFAULT.VALID_FORMATS),
                         default=defaults.DEFAULT.DEFAULT_FORMAT,
                         type=str)
     parser.add_argument('--trim', '-t', help="Trim out the audio from the song. Use \

--- a/ytmdl/core.py
+++ b/ytmdl/core.py
@@ -229,13 +229,17 @@ def meta(conv_name: str, song_name: str, search_by: str, args):
             raise NoMetaError(search_by)
 
         TRACK_INFO = manual.get_data(song_name)
+        song.setData(TRACK_INFO, IS_QUIET, conv_name, PASSED_FORMAT, args.choice)
         return TRACK_INFO
 
     logger.info('Setting data...')
     option = song.setData(TRACK_INFO, IS_QUIET, conv_name, PASSED_FORMAT,
                           args.choice)
-
-    if type(option) is not int:
+    if option == '~':
+        TRACK_INFO = manual.get_data(song_name)
+        song.setData(TRACK_INFO, IS_QUIET, conv_name, PASSED_FORMAT, args.choice)
+        return TRACK_INFO
+    elif type(option) is not int:
         raise MetadataError(search_by)
 
     return TRACK_INFO[option]

--- a/ytmdl/manual.py
+++ b/ytmdl/manual.py
@@ -98,6 +98,7 @@ def get_data(query_name):
     meta = Meta()
     meta.track_name = query_name
     meta.read_values()
+    logger.debug('Manually retrieved metadata.')
     return [meta]
 
 


### PR DESCRIPTION
Many of the songs I want to add using this tool either do not have metadata that can be found, or the metadata that is found is incorrect. To fix this, I believe the user should always have the option to override the metadata suggested with their own manual entry.

- I changed the default setting for the `--on-meta-error` parameter to `manual`. Now, if there is an error, the user will be given the chance to enter their metadata immediately and by default.

- I also added a special `~` option to menus where metadata selection is available to let the user skip any of the suggested metadata and input their own metadata.

Thanks for the excellent tool.