### PR TITLE
Add flag to lookup metadata by iTunes id

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Metadata:
                         song to the destination directory. '--manual-meta'
                         will override this option, pass only one of them.
   -m, --manual-meta     Manually enter song details.
+  --itunes-id           Direct lookup from iTunes by id.
   --disable-sort        Disable sorting of the metadata before asking for
                         input. Useful if the song is in some other language
                         and/or just a few providers are used.

--- a/bin/ytmdl
+++ b/bin/ytmdl
@@ -90,6 +90,7 @@ def arguments():
                         action="store_true")
     metadata_group.add_argument('-m', '--manual-meta', help="Manually enter song\
                         details.", action="store_true")
+    metadata_group.add_argument('--itunes-id', help="Direct lookup from itunes.")
     metadata_group.add_argument("--disable-sort", help="Disable sorting of the metadata \
                         before asking for input. Useful if the song is in some other language \
                         and/or just a few providers are used.", action="store_true")

--- a/ytmdl/core.py
+++ b/ytmdl/core.py
@@ -215,6 +215,9 @@ def meta(conv_name: str, song_name: str, search_by: str, args):
         # Since above code will return a list with just
         # one element, the option will be set to 0 by
         # default and won't ask the user
+    elif args.itunes_id:
+        logger.info('Direct iTunes lookup for {}...'.format(args.itunes_id))
+        TRACK_INFO = metadata.lookup_from_itunes(args.itunes_id)
     else:
         # Else add metadata in ordinary way
         logger.info('Getting song data for {}...'.format(search_by))

--- a/ytmdl/metadata.py
+++ b/ytmdl/metadata.py
@@ -84,6 +84,19 @@ def get_from_musicbrainz(SONG_NAME):
         return None
 
 
+def lookup_from_itunes(ID):
+    """Lookup metadata by id using itunespy."""
+    # Try to get the song data from itunes
+    try:
+        SONG_INFO = itunespy.lookup_track(int(ID))
+        # Only keep track results
+        SONG_INFO = [i for i in SONG_INFO if i.type == 'track']
+        return SONG_INFO
+    except Exception as e:
+        _logger_provider_error(e, 'iTunes')
+        return None
+
+
 def _search_tokens(song_name, song_list):
     """Search song in the cache based on simple each word matching."""
     song_name = remove_punct(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/deepjyoti30/ytmdl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [ytmdl coding conventions](https://github.com/deepjyoti30/ytmdl/blob/master/.github/CONTRIBUTING.md) and adjusted the code to meet them
- [x] Checked the code with [pylama](https://github.com/klen/pylama)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New feature

---

### Description of your *pull request* and other information

Add a flag that allows you to specify an iTunes id to directly lookup metadata. You can get iTunes ids from the URL when browsing. I have had trouble with the search functionality not finding the right results so this is a workaround for that without needing to manually pull all metadata.
