### PR TITLE
Add an output flag argument properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ You can manually install `ytmdl` by cloning this repository and running the `set
 1. Clone this repo:
 
     ```console
-    git clone https://github.com/deepjyoti30/ytmdl   
+    git clone https://github.com/deepjyoti30/ytmdl
     ```
 
 1. Move into the `ytmdl` directory and run the `setup.py` script:
@@ -157,7 +157,7 @@ You can manually install `ytmdl` by cloning this repository and running the `set
 ## Usage
 
 ```console
-usage: ytmdl [-h] [-q] [--song SONG-METADATA] [--choice CHOICE]
+usage: ytmdl [-h] [-q] [-o SONG-DIR] [--song SONG-METADATA] [--choice CHOICE]
              [--artist ARTIST] [--album ALBUM] [--disable-metaadd]
              [--skip-meta] [-m] [--itunes-id ITUNES_ID]
              [--spotify-id SPOTIFY_ID] [--disable-sort] [--ask-meta-name]
@@ -178,6 +178,9 @@ optional arguments:
   -q, --quiet           Don't ask the user to select songs if more than one
                         search result. The first result in each case will be
                         considered.
+  -o, --output          The location for the song to be downloaded
+                        to. When no argument is passed, the default locations
+                        of SONG_DIR or XDG_MUSIC_DIR are used.
   --proxy URL           Use the specified HTTP/HTTPS/SOCKS proxy. To enable
                         SOCKS proxy, specify a proper scheme. For example
                         socks5://127.0.0.1:1080/. Pass in an empty string
@@ -342,4 +345,3 @@ As of the latest source, the following options can be passed to the special stri
 | `Genre`       | Genre Of the Song             |
 | `TrackNumber` | TrackNumber Of the Song       |
 | `ReleaseDate` | ReleaseDate Of the Song       |
-

--- a/bin/ytmdl
+++ b/bin/ytmdl
@@ -67,6 +67,10 @@ def arguments():
                         if more than one search result.\
                         The first result in each case will be considered.",
                         action='store_true')
+    parser.add_argument('-o', '--output',
+                        help="The location for the song to be downloaded\
+                        to. When no argument is passed, the default locations\
+                        of SONG_DIR or XDG_MUSIC_DIR are used.")
     metadata_group = parser.add_argument_group("Metadata")
     metadata_group.add_argument(
         '--song', help="The song to search in Metadata. \
@@ -442,6 +446,13 @@ def pre_checks(args):
         print(" ".join(("--{}".format(opt.replace("_", "-"))
               for opt in vars(args))))
         exit(0)
+
+    # Ensure the output directory is legitimate
+    if (args.output is not None):
+        if path.isdir(path.expanduser(args.output)):
+            defaults.DEFAULT.SONG_DIR = path.expanduser(args.output)
+        else:
+            logger.warning("{}: is an invalid path. Continuing with default.".format(args.output))
 
     # Extract on-meta-error
     logger.debug("on_meta_error before: ", str(args.on_meta_error))

--- a/ytmdl/dir.py
+++ b/ytmdl/dir.py
@@ -23,7 +23,7 @@ def __replace_special_characters(passed_name: str) -> str:
 
 
 def cleanup(TRACK_INFO, index, datatype, remove_cached=True):
-    """Move the song from temp to $HOME/Music dir."""
+    """Move the song from temp to the song dir."""
     try:
         SONG = glob.glob(os.path.join(
             defaults.DEFAULT.SONG_TEMP_DIR,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/deepjyoti30/ytmdl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [ytmdl coding conventions](https://github.com/deepjyoti30/ytmdl/blob/master/.github/CONTRIBUTING.md) and adjusted the code to meet them
- [x] Checked the code with [pylama](https://github.com/klen/pylama)
- [x] Made the pull request to the **unstable** branch

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New feature

---

### Description of your *pull request* and other information

As conceived in #196, this is an evolution of that idea. I completely agree that reading from the environment is a bit dumb, so instead a standard argument is implemented (as most CLI utilities use), `--output/-o`. This reads the directory, ensures it is valid, and uses that instead of the other song directories. The config still overrides this argument, which seems to maintain the feel that you want.

Fixed this time to be based on unstable!