### PR TITLE
Include release date in prompts

### DIFF
--- a/ytmdl/song.py
+++ b/ytmdl/song.py
@@ -100,6 +100,10 @@ def print_choice(beg, end, SONG_INFO, type):
         print(Fore.YELLOW, end='')
         if type == 'metadata':
             print(SONG_INFO[beg].artist_name, end='')
+            print(Style.RESET_ALL, end='')
+            print(' released ', end='')
+            print(Fore.GREEN, end='')
+            print(SONG_INFO[beg].release_date, end='')
         if type == 'mp3':
             print(SONG_INFO[beg]['author_name'], end='')
             print(Style.RESET_ALL, end='')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/deepjyoti30/ytmdl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
_None mention 'date'_
- [x] Read [ytmdl coding conventions](https://github.com/deepjyoti30/ytmdl/blob/master/.github/CONTRIBUTING.md) and adjusted the code to meet them
_None seemed applicable_
- [x] Checked the code with [pylama](https://github.com/klen/pylama)
_Plenty of hits, but none in song.py_
- [x] Made the pull request to the **unstable** branch
_Sure._

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature

---

### Description of your *pull request* and other information

In short, if a song has been released on multiple albums by the same artist, the default prompt for metadata is very unhelpful:
![image](https://user-images.githubusercontent.com/4315099/162643237-7a276f8d-5c24-4350-843b-5254e23192bc.png)

This adds the release date to that prompt, helping to disambiguate which one we're grabbing:
![image](https://user-images.githubusercontent.com/4315099/162643265-eb0fb131-ae83-46f4-90eb-4148c273064e.png)

To be clear, it would probably be better to include a "default" mode where we use the youtube music metadata here, but, I mean, this change unblocks me.
