### PR TITLE
Allow the search to be amended if -2 is provided as an option

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,4 @@
+github: deepjyoti30
 custom: ['https://www.paypal.me/deepjyoti30']
 patreon: deepjyoti30
 ko_fi: deepjyoti30

--- a/ytmdl/__version__.py
+++ b/ytmdl/__version__.py
@@ -1,2 +1,2 @@
 # Store the version of the package
-__version__ = "2022.03.16"
+__version__ = "2022.12.25"

--- a/ytmdl/core.py
+++ b/ytmdl/core.py
@@ -255,5 +255,11 @@ def meta(conv_name: str, song_name: str, search_by: str, args):
         logger.warning(
             "Metadata was skipped because -1 was entered as the option")
         return None
+    # If amending the search, get the new search and retry
+    elif option == -2:
+        logger.info(
+            "Amending the search because -2 was entered as the option")
+        search_by = utility.get_new_meta_search_by(search_by)
+        return meta(conv_name, song_name, search_by, args)
 
     return TRACK_INFO[option]

--- a/ytmdl/core.py
+++ b/ytmdl/core.py
@@ -230,7 +230,7 @@ def meta(conv_name: str, song_name: str, search_by: str, args):
     else:
         # Else add metadata in ordinary way
         logger.info('Getting song data for {}...'.format(search_by))
-        TRACK_INFO = metadata.SEARCH_SONG(search_by, filters=[
+        TRACK_INFO = metadata.SEARCH_SONG(search_by, song_name, filters=[
                                           args.artist, args.album],
                                           disable_sort=args.disable_sort)
 

--- a/ytmdl/metadata.py
+++ b/ytmdl/metadata.py
@@ -207,7 +207,7 @@ def _extend_to_be_sorted_and_rest(provider_data, to_be_sorted, rest, filters):
         rest.extend(provider_data[10:])
 
 
-def SEARCH_SONG(q="Tera Buzz", filters=[], disable_sort=False):
+def SEARCH_SONG(search_by="Tera Buzz", song_name="Tera Buzz", filters=[], disable_sort=False):
     """Do the task by calling other functions."""
     to_be_sorted = []
     rest = []
@@ -230,7 +230,7 @@ def SEARCH_SONG(q="Tera Buzz", filters=[], disable_sort=False):
         if provider in GET_METADATA_ACTIONS:
             logger.debug(f"Searching metadata with {provider}")
             data_provider = GET_METADATA_ACTIONS.get(
-                provider, lambda _: None)(q)
+                provider, lambda _: None)(search_by)
             if data_provider:
                 _extend_to_be_sorted_and_rest(
                     data_provider, to_be_sorted, rest, filters)
@@ -256,7 +256,7 @@ def SEARCH_SONG(q="Tera Buzz", filters=[], disable_sort=False):
         return to_be_sorted
 
     # Send the data to get sorted
-    sorted_data = _search_tokens(q, to_be_sorted)
+    sorted_data = _search_tokens(song_name, to_be_sorted)
 
     # Add the unsorted data
     sorted_data += rest
@@ -265,7 +265,7 @@ def SEARCH_SONG(q="Tera Buzz", filters=[], disable_sort=False):
 
 
 if __name__ == '__main__':
-    n = SEARCH_SONG("Cradles", ["Sub Urban", None])
+    n = SEARCH_SONG("Cradles", "Cradles", ["Sub Urban", None])
 
     for i in n:
         print(i.track_name + ' by ' + i.artist_name + ' of ' + i.collection_name)

--- a/ytmdl/song.py
+++ b/ytmdl/song.py
@@ -147,7 +147,7 @@ def getChoice(SONG_INFO, type):
 
     logger.info('Choose One {}'.format(
         '(One with [M] is verified music)'
-        if type == 'mp3' else '(Enter -1 to skip metadata)'))
+        if type == 'mp3' else '(Enter -1 to skip metadata or -2 to amend search)'))
 
     results = len(SONG_INFO)
 
@@ -172,8 +172,9 @@ def getChoice(SONG_INFO, type):
         # If the choice is 0 then try to print more results
         # The choice is valid if it is in the range and it is greater than 0
         # We also need to break when the user enters -1 which means the exec
-        # will skip the current song
-        if choice == -1 or (choice <= len(SONG_INFO) and choice > 0):
+        # will skip the current song or -2 which means the exec will amend the
+        # search and retry
+        if choice == -1 or choice == -2 or (choice <= len(SONG_INFO) and choice > 0):
             break
         elif choice == 0 and results < len(SONG_INFO):
             PRINT_WHOLE = True
@@ -182,7 +183,7 @@ def getChoice(SONG_INFO, type):
         else:
             PRINT_WHOLE = False
 
-    return choice - 1 if choice != -1 else -1
+    return choice - 1 if (choice != -1 and choice != -2) else choice
 
 
 def set_MP3_data(song, song_path):
@@ -389,8 +390,8 @@ def setData(SONG_INFO, is_quiet, song_path, datatype='mp3', choice=None):
     option = _get_option(SONG_INFO, is_quiet, choice)
     logger.debug(option)
 
-    # If -1 then skip setting the metadata
-    if option == -1:
+    # If -1 or -2 then skip setting the metadata
+    if option == -1 or option == -2:
         return option
 
     song = SONG_INFO[option]


### PR DESCRIPTION
---

- [x] [Searched](https://github.com/deepjyoti30/ytmdl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [ytmdl coding conventions](https://github.com/deepjyoti30/ytmdl/blob/master/.github/CONTRIBUTING.md) and adjusted the code to meet them
- [x] Checked the code with [pylama](https://github.com/klen/pylama)
- [x] Made the pull request to the **unstable** branch

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [x] New feature

---

### Description

After using the tool for a while, I often find myself wanting to change the search string passed to the APIs for meta searching. Often, simply including the artist name in the search along with the song name gives immediate results without having to scroll through a mass of results. With my changes, users can use -2 as an option to amend the search until they find their desired result.

![example](https://user-images.githubusercontent.com/18558188/211864727-683fbae8-b82c-4423-a718-42d1d8c0362f.png)
